### PR TITLE
Fix build errors after rand 0.9 bump: RngCore import and unused assignment

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -987,7 +987,6 @@ impl eframe::App for QsoApp {
                             if ui.button("Test Connection").clicked() {
                                 let config = self.db_config.clone();
                                 let rt = tokio::runtime::Runtime::new().unwrap();
-                                self.connection_test_result = Some("Testing connection...".to_string());
                                 match rt.block_on(async {
                                     let test_db = RemoteDatabase::new(config);
                                     test_db.test_connection().await

--- a/src/security.rs
+++ b/src/security.rs
@@ -2,8 +2,8 @@ use aes_gcm::{
     aead::{Aead, KeyInit, OsRng},
     Aes256Gcm, Nonce,
 };
+use aes_gcm::aead::rand_core::RngCore;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;


### PR DESCRIPTION
Two build fixes:

1. **`src/security.rs`** — `rand::RngCore` (v0.9) is incompatible with `aes_gcm::aead::OsRng` which re-exports `rand_core` v0.6. Changed the import to `aes_gcm::aead::rand_core::RngCore`.

2. **`src/app.rs:990`** — Removed an unused assignment to `connection_test_result` that was immediately overwritten by the synchronous `block_on` call.

Fixes the build breakage introduced by the rand 0.8→0.9 bump in #7.